### PR TITLE
Feature/gomod

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func Example() {
-
 	x := set.NewString("a", "b", "c")
 
 	fmt.Println("len(x):", len(x))
@@ -36,7 +35,6 @@ func Example() {
 }
 
 func ExampleString_Union() {
-
 	x := set.NewString("a", "b", "c")
 	y := set.NewString("b", "c", "d")
 
@@ -47,7 +45,6 @@ func ExampleString_Union() {
 }
 
 func ExampleString_Intersect() {
-
 	x := set.NewString("a", "b", "c")
 	y := set.NewString("b", "c", "d")
 
@@ -58,7 +55,6 @@ func ExampleString_Intersect() {
 }
 
 func ExampleString_Difference() {
-
 	x := set.NewString("a", "b", "c")
 	y := set.NewString("b", "c", "d")
 
@@ -69,7 +65,6 @@ func ExampleString_Difference() {
 }
 
 func ExampleNewUint() {
-
 	unsigned := set.NewUint(uint64(1), uint64(2), uint64(3))
 	fmt.Println("unsigned:", unsigned)
 
@@ -78,7 +73,6 @@ func ExampleNewUint() {
 }
 
 func ExampleNewInt() {
-
 	signed := set.NewInt(int64(-1), int64(-2), int64(-3))
 	fmt.Println("signed:", signed)
 

--- a/example_test.go
+++ b/example_test.go
@@ -3,12 +3,12 @@
 package set_test
 
 import (
-	"github.com/RAttab/goset"
+	set "github.com/RAttab/goset"
 
 	"fmt"
 )
 
-func Example_Basics() {
+func Example() {
 
 	x := set.NewString("a", "b", "c")
 
@@ -35,30 +35,53 @@ func Example_Basics() {
 	// z: [a c]
 }
 
-func Example_Operands() {
+func ExampleString_Union() {
 
 	x := set.NewString("a", "b", "c")
 	y := set.NewString("b", "c", "d")
 
 	fmt.Println("x.Union(y):", x.Union(y))
-	fmt.Println("x.Intersect(y):", x.Intersect(y))
-	fmt.Println("x.Difference(y):", x.Difference(y))
 
 	// Output:
 	// x.Union(y): { a b c d }
+}
+
+func ExampleString_Intersect() {
+
+	x := set.NewString("a", "b", "c")
+	y := set.NewString("b", "c", "d")
+
+	fmt.Println("x.Intersect(y):", x.Intersect(y))
+
+	// Output:
 	// x.Intersect(y): { b c }
+}
+
+func ExampleString_Difference() {
+
+	x := set.NewString("a", "b", "c")
+	y := set.NewString("b", "c", "d")
+
+	fmt.Println("x.Difference(y):", x.Difference(y))
+
+	// Output:
 	// x.Difference(y): { a }
 }
 
-func Example_Types() {
+func ExampleNewUint() {
 
 	unsigned := set.NewUint(uint64(1), uint64(2), uint64(3))
 	fmt.Println("unsigned:", unsigned)
+
+	// Output:
+	// unsigned: { 1 2 3 }
+}
+
+func ExampleNewInt() {
 
 	signed := set.NewInt(int64(-1), int64(-2), int64(-3))
 	fmt.Println("signed:", signed)
 
 	// Output:
-	// unsigned: { 1 2 3 }
 	// signed: { -3 -2 -1 }
 }

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module set
+
+go 1.13
+
+require github.com/RAttab/goset v0.0.0-20150721142115-5798a3bfc390

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/RAttab/goset v0.0.0-20150721142115-5798a3bfc390 h1:9nadUbCNj3iZNNaZR4yb0zz5PRqhIJFyHJA3llMwolw=
+github.com/RAttab/goset v0.0.0-20150721142115-5798a3bfc390/go.mod h1:GnBqxvr+sePRbPbuJouG06hEWpfORi9J0VIYEMHi7H8=

--- a/int_test.go
+++ b/int_test.go
@@ -58,7 +58,7 @@ func benchIntIntersect(bench *testing.B, n, m int) {
 		a.Put(int64(i))
 	}
 
-	for i := 0; i < n; i = i + 2 {
+	for i := 0; i < n; i += 2 {
 		b.Put(int64(i))
 		m--
 	}

--- a/string_test.go
+++ b/string_test.go
@@ -59,7 +59,7 @@ func benchStringIntersect(bench *testing.B, n, m int) {
 		a.Put(strconv.FormatInt(int64(i), 10))
 	}
 
-	for i := 0; i < n; i = i + 2 {
+	for i := 0; i < n; i += 2 {
 		b.Put(strconv.FormatInt(int64(i), 10))
 		m--
 	}

--- a/uint_test.go
+++ b/uint_test.go
@@ -58,7 +58,7 @@ func benchUuintIntersect(bench *testing.B, n, m int) {
 		a.Put(uint64(i))
 	}
 
-	for i := 0; i < n; i = i + 2 {
+	for i := 0; i < n; i += 2 {
 		b.Put(uint64(i))
 		m--
 	}


### PR DESCRIPTION
- Introduce `go.mod` and set version to 1.13
- Fix examples to make `go vet` happy.
- Passes everything except `dupl` and `wsl` in `golangci-lint`